### PR TITLE
Spelling of "variable" corrected in quick_examples.cpp

### DIFF
--- a/example/quick_examples.cpp
+++ b/example/quick_examples.cpp
@@ -55,7 +55,7 @@ void test_examples() {
 
   {
 //[pfr_quick_examples_for_each_idx
-    // Iterate over fields of a varible and output index and
+    // Iterate over fields of a variable and output index and
     // type of a variable.
 
     struct tag0{};


### PR DESCRIPTION
This is my first contribution in Open Source. I have corrected the spelling of "variable" in a comment. I am looking forward to contribute to Boost.